### PR TITLE
add support for custom fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Downloads](https://img.shields.io/npm/dm/expo-share-extension.svg)
 ![GitHub stars](https://img.shields.io/github/stars/MaxAst/expo-share-extension.svg)
 
-Create an [iOS share extension](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Share.html) with a custom view (similar to e.g. Pinterest). Supports Apple Sign-In, [React Native Firebase](https://rnfirebase.io/) (including shared auth session via access groups), custom background, and custom heights.
+Create an [iOS share extension](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Share.html) with a custom view (similar to e.g. Pinterest). Supports Apple Sign-In, [React Native Firebase](https://rnfirebase.io/) (including shared auth session via access groups), custom background, custom height, and custom fonts.
 
 **Note**: The extension currently only works for Safari's share menu, where a `url` prop is passed to the extension's root component as an initial prop. Contributions to support more [NSExtensionActivationRules](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AppExtensionKeys.html#//apple_ref/doc/uid/TP40014212-SW10) are welcome!
 
@@ -149,6 +149,12 @@ Want to customize the share extension's height? Do this in your `app.json`/`app.
     },
 ],
 ```
+
+### Custom Fonts
+
+This plugin automatically adds custom fonts to the share extension target if they are [embedded in the native project](https://docs.expo.dev/develop/user-interface/fonts/#embed-font-in-a-native-project) via the `expo-font` config plugin.
+
+It currently does not support custom fonts that are [loaded at runtime](https://docs.expo.dev/develop/user-interface/fonts/#load-font-at-runtime), due to an `NSURLSesssion` [eror](https://stackoverflow.com/questions/26172783/upload-nsurlsesssion-becomes-invalidated-in-sharing-extension-in-ios8-with-error). To fix this, Expo would need to support defining a [`sharedContainerIdentifier`](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1409450-sharedcontaineridentifier) for `NSURLSessionConfiguration` instances, where the value would be set to the main app's and share extension's app group identifier (e.g. `group.com.example.app`).
 
 ## Development
 

--- a/examples/basic/App.tsx
+++ b/examples/basic/App.tsx
@@ -1,30 +1,23 @@
-import { useFonts } from "expo-font";
-import * as SplashScreen from "expo-splash-screen";
-import { useCallback } from "react";
-import { Alert, Button, StyleSheet, Text, View } from "react-native";
-
-SplashScreen.preventAutoHideAsync();
+import { StyleSheet, Text, View } from "react-native";
 
 export default function App() {
-  const [fontsLoaded, fontError] = useFonts({
-    "Inter-Black": require("./assets/fonts/Inter-Black.otf"),
-  });
-
-  const onLayoutRootView = useCallback(async () => {
-    if (fontsLoaded || fontError) {
-      await SplashScreen.hideAsync();
-    }
-  }, [fontsLoaded, fontError]);
-
-  if (!fontsLoaded && !fontError) {
-    return null;
-  }
-
   return (
-    <View onLayout={onLayoutRootView} style={styles.container}>
-      <Text style={{ color: "#313639", fontFamily: "Inter-Black" }}>ho</Text>
-      <Text style={{ color: "#313639", fontFamily: "Inter-Black" }}>hi</Text>
-      <Button title="Add from App" onPress={() => Alert.alert("added")} />
+    <View style={styles.container}>
+      <Text
+        style={{ fontFamily: "Inter-Black", fontSize: 24, marginBottom: 10 }}
+      >
+        Basic Example
+      </Text>
+      <Text
+        style={{
+          textAlign: "center",
+          color: "#313639",
+          fontSize: 16,
+        }}
+      >
+        Go to Safari and open the share menu to trigger this app's share
+        extension.
+      </Text>
     </View>
   );
 }
@@ -35,5 +28,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#FAF8F5",
     alignItems: "center",
     justifyContent: "center",
+    padding: 30,
   },
 });

--- a/examples/basic/ShareExtension.tsx
+++ b/examples/basic/ShareExtension.tsx
@@ -1,17 +1,35 @@
-import { close } from "expo-share-extension"
-import { Button, Text, View } from "react-native";
+import { close } from "expo-share-extension";
+import { Button, StyleSheet, Text, View } from "react-native";
 
 export default function ShareExtension({ url }: { url: string }) {
   return (
-    <View
-      style={{
-        backgroundColor: "transparent",
-        flex: 1,
-        alignItems: "center",
-      }}
-    >
-      <Text style={{ fontSize: 30 }}>{url}</Text>
+    <View style={styles.container}>
+      <Text
+        style={{ fontFamily: "Inter-Black", fontSize: 24, marginBottom: 10 }}
+      >
+        Basic Example
+      </Text>
+      <Text
+        style={{
+          textAlign: "center",
+          color: "#313639",
+          fontSize: 16,
+        }}
+      >
+        URL: {url}
+      </Text>
       <Button title="Close" onPress={close} />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    borderRadius: 20,
+    backgroundColor: "#FAF8F5",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 30,
+  },
+});

--- a/examples/basic/app.json
+++ b/examples/basic/app.json
@@ -28,13 +28,19 @@
     },
     "plugins": [
       [
+        "expo-font",
+        {
+          "fonts": ["./assets/fonts/Inter-Black.otf"]
+        }
+      ],
+      [
         "../../app.plugin.js",
         {
           "backgroundColor": {
             "red": 255,
             "green": 255,
             "blue": 255,
-            "alpha": 0.9
+            "alpha": 0 // make the background transparent
           },
           "height": 500
         }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -54,6 +54,12 @@ const withShareExtension: ConfigPlugin<{
     rgbaSchema.parse(props.backgroundColor);
   }
 
+  const expoFontPlugin = config.plugins?.find(
+    (p) => Array.isArray(p) && p.length && p.at(0) === "expo-font"
+  );
+
+  const fonts = expoFontPlugin?.at(1).fonts ?? [];
+
   return withPlugins(config, [
     withExpoConfig,
     withAppEntitlements,
@@ -63,6 +69,7 @@ const withShareExtension: ConfigPlugin<{
       {
         backgroundColor: props?.backgroundColor,
         height: props?.height,
+        fonts,
       },
     ],
     withShareExtensionEntitlements,
@@ -70,6 +77,7 @@ const withShareExtension: ConfigPlugin<{
       withShareExtensionTarget,
       {
         googleServicesFile: props?.googleServicesFile,
+        fonts,
       },
     ],
   ]);

--- a/plugin/src/withShareExtensionInfoPlist.ts
+++ b/plugin/src/withShareExtensionInfoPlist.ts
@@ -12,7 +12,8 @@ import {
 export const withShareExtensionInfoPlist: ConfigPlugin<{
   backgroundColor?: BackgroundColor;
   height?: Height;
-}> = (config, { backgroundColor, height }) => {
+  fonts: string[];
+}> = (config, { backgroundColor, height, fonts }) => {
   return withInfoPlist(config, (config) => {
     const targetName = getShareExtensionName(config);
 
@@ -53,6 +54,7 @@ export const withShareExtensionInfoPlist: ConfigPlugin<{
         UIApplicationSupportsMultipleScenes: true,
         UISceneConfigurations: {},
       },
+      UIAppFonts: fonts.map((font) => path.basename(font)) ?? [],
       NSExtension: {
         NSExtensionAttributes: {
           NSExtensionActivationRule: {

--- a/plugin/src/withShareExtensionTarget.ts
+++ b/plugin/src/withShareExtensionTarget.ts
@@ -16,7 +16,8 @@ import { addXCConfigurationList } from "./xcode/addToXCConfigurationList";
 
 export const withShareExtensionTarget: ConfigPlugin<{
   googleServicesFile?: string;
-}> = (config, { googleServicesFile }) => {
+  fonts: string[];
+}> = (config, { googleServicesFile, fonts = [] }) => {
   return withXcodeProject(config, async (config) => {
     const xcodeProject = config.modResults;
 
@@ -29,7 +30,7 @@ export const withShareExtensionTarget: ConfigPlugin<{
     const { platformProjectRoot, projectRoot } = config.modRequest;
 
     if (config.ios?.googleServicesFile && !googleServicesFile) {
-      console.log(
+      console.warn(
         "Warning: No Google Services file specified for Share Extension"
       );
     }
@@ -65,13 +66,19 @@ export const withShareExtensionTarget: ConfigPlugin<{
       targetName,
       platformProjectRoot,
       googleServicesFilePath,
+      fonts,
     });
 
     addBuildPhases(xcodeProject, {
       targetUuid,
       groupName,
       productFile,
-      resources: googleServicesFilePath ? ["GoogleService-Info.plist"] : [],
+      resources: googleServicesFilePath
+        ? [
+            "GoogleService-Info.plist",
+            ...fonts.map((font: string) => path.basename(font)),
+          ]
+        : fonts.map((font: string) => path.basename(font)),
     });
 
     return config;

--- a/plugin/src/xcode/addPbxGroup.ts
+++ b/plugin/src/xcode/addPbxGroup.ts
@@ -8,10 +8,12 @@ export function addPbxGroup(
     targetName,
     platformProjectRoot,
     googleServicesFilePath,
+    fonts = [],
   }: {
     targetName: string;
     platformProjectRoot: string;
     googleServicesFilePath?: string;
+    fonts: string[];
   }
 ) {
   const targetPath = path.join(platformProjectRoot, targetName);
@@ -35,6 +37,10 @@ export function addPbxGroup(
     copyFileSync(googleServicesFilePath, targetPath);
   }
 
+  for (const font of fonts) {
+    copyFileSync(font, targetPath);
+  }
+
   // Add PBX group
   const { uuid: pbxGroupUuid } = xcodeProject.addPbxGroup(
     googleServicesFilePath
@@ -43,11 +49,13 @@ export function addPbxGroup(
           "Info.plist",
           `${targetName}.entitlements`,
           "GoogleService-Info.plist",
+          ...fonts.map((font: string) => path.basename(font)),
         ]
       : [
           "ShareExtensionViewController.swift",
           "Info.plist",
           `${targetName}.entitlements`,
+          ...fonts.map((font: string) => path.basename(font)),
         ],
     targetName,
     targetName


### PR DESCRIPTION
allows using custom fonts that are [embedded in the native project](https://docs.expo.dev/develop/user-interface/fonts/#embed-font-in-a-native-project), but does not fix #1, which is about loading custom fonts (and icons from @expo/vector-icons) at runtime