### PR TITLE
Fix google auth in share extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always"
+  },
+  "eslint.format.enable": true,
+  "lldb.library": "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB",
+  "lldb.launch.expressions": "native"
+}

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -56,7 +56,7 @@ const withShareExtension: ConfigPlugin<{
   }
 
   const expoFontPlugin = config.plugins?.find(
-    (p) => Array.isArray(p) && p.length && p.at(0) === "expo-font"
+    (p) => Array.isArray(p) && p.length && p.at(0) === "expo-font",
   );
 
   const fonts = expoFontPlugin?.at(1).fonts ?? [];
@@ -72,6 +72,7 @@ const withShareExtension: ConfigPlugin<{
         backgroundColor: props?.backgroundColor,
         height: props?.height,
         preprocessingFile: props.preprocessingFile,
+        googleServicesFile: props?.googleServicesFile,
       },
     ],
     withShareExtensionEntitlements,

--- a/plugin/src/withExpoConfig.ts
+++ b/plugin/src/withExpoConfig.ts
@@ -25,7 +25,7 @@ export const withExpoConfig: ConfigPlugin = (config) => {
     config.extra?.eas?.build?.experimental?.ios?.appExtensions;
 
   const shareExtensionConfig = iosExtensions?.find(
-    (extension) => extension.targetName === extensionName
+    (extension) => extension.targetName === extensionName,
   );
 
   return {
@@ -49,7 +49,7 @@ export const withExpoConfig: ConfigPlugin = (config) => {
                   entitlements: {
                     ...shareExtensionConfig?.entitlements,
                     "com.apple.security.application-groups": getAppGroups(
-                      config.ios?.bundleIdentifier
+                      config.ios?.bundleIdentifier,
                     ),
                     ...(config.ios.usesAppleSignIn && {
                       "com.apple.developer.applesignin": ["Default"],
@@ -57,7 +57,7 @@ export const withExpoConfig: ConfigPlugin = (config) => {
                   },
                 },
                 ...(iosExtensions?.filter(
-                  (extension) => extension.targetName !== extensionName
+                  (extension) => extension.targetName !== extensionName,
                 ) ?? []),
               ],
             },

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -14,7 +14,7 @@ export const withPodfile: ConfigPlugin<{
     (config) => {
       const podFilePath = path.join(
         config.modRequest.platformProjectRoot,
-        "Podfile"
+        "Podfile",
       );
       let podfileContent = fs.readFileSync(podFilePath).toString();
 

--- a/plugin/src/withShareExtensionEntitlements.ts
+++ b/plugin/src/withShareExtensionEntitlements.ts
@@ -15,7 +15,7 @@ export const withShareExtensionEntitlements: ConfigPlugin = (config) => {
 
     const targetPath = path.join(
       config.modRequest.platformProjectRoot,
-      targetName
+      targetName,
     );
     const filePath = path.join(targetPath, `${targetName}.entitlements`);
 

--- a/plugin/src/withShareExtensionTarget.ts
+++ b/plugin/src/withShareExtensionTarget.ts
@@ -32,7 +32,7 @@ export const withShareExtensionTarget: ConfigPlugin<{
 
     if (config.ios?.googleServicesFile && !googleServicesFile) {
       console.warn(
-        "Warning: No Google Services file specified for Share Extension"
+        "Warning: No Google Services file specified for Share Extension",
       );
     }
 

--- a/plugin/src/xcode/addBuildPhases.ts
+++ b/plugin/src/xcode/addBuildPhases.ts
@@ -17,7 +17,7 @@ export function addBuildPhases(
       group: string;
     };
     resources: string[];
-  }
+  },
 ) {
   const buildPath = `"$(CONTENTS_FOLDER_PATH)/ShareExtensions"`;
   const targetType = "app_extension";
@@ -33,7 +33,7 @@ export function addBuildPhases(
       shellScript:
         'export RCT_METRO_PORT="${RCT_METRO_PORT:=8081}"\necho "export RCT_METRO_PORT=${RCT_METRO_PORT}" > "${SRCROOT}/../node_modules/react-native/scripts/.packager.env"\nif [ -z "${RCT_NO_LAUNCH_PACKAGER+xxx}" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s "http://localhost:${RCT_METRO_PORT}/status" | grep -q "packager-status:running" ; then\n      echo "Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly"\n      exit 2\n    fi\n  else\n    open "$SRCROOT/../node_modules/react-native/scripts/launchPackager.command" || echo "Can\'t start packager automatically"\n  fi\nfi\n',
     },
-    buildPath
+    buildPath,
   );
 
   // Sources build phase
@@ -43,7 +43,7 @@ export function addBuildPhases(
     groupName,
     targetUuid,
     targetType,
-    buildPath
+    buildPath,
   );
 
   // Copy files build phase
@@ -52,7 +52,7 @@ export function addBuildPhases(
     "PBXCopyFilesBuildPhase",
     groupName,
     xcodeProject.getFirstTarget().uuid,
-    targetType
+    targetType,
   );
 
   xcodeProject.addBuildPhase(
@@ -60,7 +60,7 @@ export function addBuildPhases(
     "PBXCopyFilesBuildPhase",
     "Copy Files",
     xcodeProject.getFirstTarget().uuid,
-    targetType
+    targetType,
   );
   xcodeProject.addToPbxCopyfilesBuildPhase(productFile);
 
@@ -71,7 +71,7 @@ export function addBuildPhases(
     groupName,
     targetUuid,
     targetType,
-    buildPath
+    buildPath,
   );
 
   // Resources build phase
@@ -81,7 +81,7 @@ export function addBuildPhases(
     groupName,
     targetUuid,
     targetType,
-    buildPath
+    buildPath,
   );
 
   // Add shell script build phase
@@ -95,6 +95,6 @@ export function addBuildPhases(
       shellScript:
         'set -e; NODE_BINARY=${NODE_BINARY:-node}; REACT_NATIVE_SCRIPTS_PATH=$("$NODE_BINARY" --print "require(\'path\').dirname(require.resolve(\'react-native/package.json\')) + \'/scripts\'"); WITH_ENVIRONMENT="$REACT_NATIVE_SCRIPTS_PATH/xcode/with-environment.sh"; REACT_NATIVE_XCODE="$REACT_NATIVE_SCRIPTS_PATH/react-native-xcode.sh"; export ENTRY_FILE=index.share.js; /bin/sh -c "$WITH_ENVIRONMENT $REACT_NATIVE_XCODE";',
     },
-    buildPath
+    buildPath,
   );
 }

--- a/plugin/src/xcode/addPbxGroup.ts
+++ b/plugin/src/xcode/addPbxGroup.ts
@@ -16,7 +16,7 @@ export function addPbxGroup(
     fonts: string[];
     googleServicesFilePath?: string;
     preprocessingFilePath?: string;
-  }
+  },
 ) {
   const targetPath = path.join(platformProjectRoot, targetName);
 
@@ -27,7 +27,7 @@ export function addPbxGroup(
   copyFileSync(
     path.join(__dirname, "../../swift/ShareExtensionViewController.swift"),
     targetPath,
-    "ShareExtensionViewController.swift"
+    "ShareExtensionViewController.swift",
   );
 
   for (const font of fonts) {
@@ -55,7 +55,7 @@ export function addPbxGroup(
   const { uuid: pbxGroupUuid } = xcodeProject.addPbxGroup(
     files,
     targetName,
-    targetName
+    targetName,
   );
 
   // Add PBXGroup to top level group

--- a/plugin/src/xcode/addProductFile.ts
+++ b/plugin/src/xcode/addProductFile.ts
@@ -2,7 +2,7 @@ import { XcodeProject } from "expo/config-plugins";
 
 export function addProductFile(
   xcodeProject: XcodeProject,
-  { targetName }: { targetName: string; groupName: string }
+  { targetName }: { targetName: string; groupName: string },
 ) {
   const productFile = xcodeProject.addProductFile(targetName, {
     group: "Copy Files",

--- a/plugin/src/xcode/addTargetDependency.ts
+++ b/plugin/src/xcode/addTargetDependency.ts
@@ -2,7 +2,7 @@ import { XcodeProject } from "expo/config-plugins";
 
 export function addTargetDependency(
   xcodeProject: XcodeProject,
-  target: { uuid: string }
+  target: { uuid: string },
 ) {
   if (!xcodeProject.hash.project.objects["PBXTargetDependency"]) {
     xcodeProject.hash.project.objects["PBXTargetDependency"] = {};

--- a/plugin/src/xcode/addToPbxNativeTargetSection.ts
+++ b/plugin/src/xcode/addToPbxNativeTargetSection.ts
@@ -12,7 +12,7 @@ export function addToPbxNativeTargetSection(
     targetUuid: string;
     productFile: { fileRef: string };
     xCConfigurationList: { uuid: string };
-  }
+  },
 ) {
   const target = {
     uuid: targetUuid,

--- a/plugin/src/xcode/addToPbxProjectSection.ts
+++ b/plugin/src/xcode/addToPbxProjectSection.ts
@@ -2,7 +2,7 @@ import { XcodeProject } from "expo/config-plugins";
 
 export function addToPbxProjectSection(
   xcodeProject: XcodeProject,
-  target: { uuid: string }
+  target: { uuid: string },
 ) {
   xcodeProject.addToPbxProjectSection(target);
 

--- a/plugin/src/xcode/addToXCConfigurationList.ts
+++ b/plugin/src/xcode/addToXCConfigurationList.ts
@@ -12,7 +12,7 @@ export function addXCConfigurationList(
     currentProjectVersion: string;
     bundleIdentifier: string;
     marketingVersion?: string;
-  }
+  },
 ) {
   const commonBuildSettings = {
     CLANG_ENABLE_MODULES: "YES",
@@ -51,7 +51,7 @@ export function addXCConfigurationList(
   const xCConfigurationList = xcodeProject.addXCConfigurationList(
     buildConfigurationsList,
     "Release",
-    `Build configuration list for PBXNativeTarget "${targetName}"`
+    `Build configuration list for PBXNativeTarget "${targetName}"`,
   );
 
   return xCConfigurationList;


### PR DESCRIPTION
Noticed that when no auth session exists, and I try to log in with Google from the share extension view, I get this error:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '|presentingViewController| must be set.'
```

This might get fixed by adding the `REVERSED_CLIENT_ID` from the Google Services file to the `CFBundleURLSchemes` array in the share extension's Info.plist