### PR TITLE
Clear shared files in app group container

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,28 @@ export default function ShareExtension({ url }: { url: string }) {
 }
 ```
 
+When you share images and videos, `expo-share-extension` stores them in a `sharedData` directory in your app group's container.
+These files are not automatically cleaned up, so you should delete them when you're done with them. You can use the `clearAppGroupContainer` method from `expo-share-extension` to delete them:
+
+```ts
+import { clearAppGroupContainer } from "expo-share-extension"
+import { Button, Text, View } from "react-native";
+
+// if ShareExtension is your root component, url is available as an initial prop
+export default function ShareExtension({ url }: { url: string }) {
+  const handleCleanUp = async () => {
+    await clearAppGroupContainer()
+  }
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Text>I have finished processing all shared images and videos</Text>
+      <Button title="Clear App Group Container" onPress={handleOpenHostApp} />
+    </View>
+  );
+}
+```
+
 ## Options
 
 ### Exlude Expo Modules

--- a/examples/with-media/app/create.tsx
+++ b/examples/with-media/app/create.tsx
@@ -1,8 +1,55 @@
+import * as FileSystem from "expo-file-system";
 import { useLocalSearchParams } from "expo-router";
-import { StyleSheet, Text, View } from "react-native";
+import { clearAppGroupContainer } from "expo-share-extension";
+import { useCallback, useEffect } from "react";
+import { Button, StyleSheet, Text, View } from "react-native";
 
 export default function Create() {
   const { videoUrl } = useLocalSearchParams();
+
+  const checkSharedDataDirectory = useCallback(async () => {
+    if (!videoUrl || typeof videoUrl !== "string") return;
+    const regex = /(.*\/AppGroup\/)/;
+    const match = videoUrl.match(regex);
+
+    const appGroupPath = match ? match[1] : null;
+
+    if (!appGroupPath) {
+      throw new Error(
+        "Failed to parse AppGroup path from iOS share extension video url"
+      );
+    }
+
+    try {
+      const files = await FileSystem.readDirectoryAsync(appGroupPath);
+      console.log(
+        "Includes sharedData directory?",
+        files.includes("sharedData")
+      );
+      if (files.includes("sharedData")) {
+        const sharedDataFiles = await FileSystem.readDirectoryAsync(
+          `${appGroupPath}sharedData`
+        );
+        console.log(sharedDataFiles);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }, [videoUrl]);
+
+  useEffect(() => {
+    checkSharedDataDirectory();
+  }, [videoUrl]);
+
+  const handleClearAppGroupContainer = async () => {
+    try {
+      await clearAppGroupContainer();
+    } catch (error) {
+      console.error(error);
+    }
+
+    await checkSharedDataDirectory();
+  };
 
   return (
     <View style={styles.container}>
@@ -20,6 +67,10 @@ export default function Create() {
       >
         {videoUrl ? `Video URL: ${videoUrl}` : "No video url"}
       </Text>
+      <Button
+        title="Delete Data in App Group Container"
+        onPress={handleClearAppGroupContainer}
+      />
     </View>
   );
 }

--- a/examples/with-media/package-lock.json
+++ b/examples/with-media/package-lock.json
@@ -12,6 +12,7 @@
         "expo": "~51.0.8",
         "expo-constants": "~16.0.1",
         "expo-dev-client": "~4.0.14",
+        "expo-file-system": "~17.0.1",
         "expo-linking": "~6.3.1",
         "expo-router": "~3.5.14",
         "expo-splash-screen": "~0.27.4",

--- a/examples/with-media/package.json
+++ b/examples/with-media/package.json
@@ -24,7 +24,8 @@
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",
     "expo-linking": "~6.3.1",
-    "expo-constants": "~16.0.1"
+    "expo-constants": "~16.0.1",
+    "expo-file-system": "~17.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.24.6",

--- a/ios/ExpoShareExtensionModule.swift
+++ b/ios/ExpoShareExtensionModule.swift
@@ -13,24 +13,47 @@ public class ExpoShareExtensionModule: Module {
       NotificationCenter.default.post(name: NSNotification.Name("openHostApp"), object: nil, userInfo: userInfo)
     }
 
-    Function("clearMedia") { () in
-      guard let appGroup = Bundle.main.object(forInfoDictionaryKey: "AppGroup") as? String else {
-        print("Could not find AppGroup in info.plist")
-        return
-      }
-              
-      guard let containerUrl = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
-        print("Could not set up file manager container URL for app group")
-        return
-      }
+    AsyncFunction("clearAppGroupContainer") { (promise: Promise) in
+      DispatchQueue.global(qos: .background).async {
+        guard let appGroup = Bundle.main.object(forInfoDictionaryKey: "AppGroup") as? String else {
+          DispatchQueue.main.async {
+            promise.reject("ERR_APP_GROUP", "Could not find AppGroup in info.plist")
+          }
+          return
+        }
 
-      let fileManager = FileManager.default
-      let mediaUrl = containerUrl.appendingPathComponent("media")
+        guard let containerUrl = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
+          DispatchQueue.main.async {
+            promise.reject("ERR_CONTAINER_URL", "Could not set up file manager container URL for app group")
+          }
+          return
+        }
 
-      do {
-        try fileManager.removeItem(at: mediaUrl)
-      } catch {
-        print("Error removing media folder: \(error)")
+        let fileManager = FileManager.default
+        let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
+
+        if fileManager.fileExists(atPath: sharedDataUrl.path) {
+          do {
+            let contents = try fileManager.contentsOfDirectory(atPath: sharedDataUrl.path)
+            for item in contents {
+              let itemPath = sharedDataUrl.appendingPathComponent(item).path
+              try fileManager.removeItem(atPath: itemPath)
+            }
+            DispatchQueue.main.async {
+              print("sharedData directory contents removed successfully.")
+              promise.resolve()
+            }
+          } catch {
+            DispatchQueue.main.async {
+              promise.reject("ERR_REMOVE_CONTENTS", "Error removing sharedData directory contents: \(error)")
+            }
+          }
+        } else {
+          DispatchQueue.main.async {
+            print("sharedData directory does not exist.")
+            promise.resolve()
+          }
+        }
       }
     }
   }

--- a/ios/ExpoShareExtensionModule.swift
+++ b/ios/ExpoShareExtensionModule.swift
@@ -12,5 +12,26 @@ public class ExpoShareExtensionModule: Module {
       let userInfo: [String: String] = ["path": path]
       NotificationCenter.default.post(name: NSNotification.Name("openHostApp"), object: nil, userInfo: userInfo)
     }
+
+    Function("clearMedia") { () in
+      guard let appGroup = Bundle.main.object(forInfoDictionaryKey: "AppGroup") as? String else {
+        print("Could not find AppGroup in info.plist")
+        return
+      }
+              
+      guard let containerUrl = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
+        print("Could not set up file manager container URL for app group")
+        return
+      }
+
+      let fileManager = FileManager.default
+      let mediaUrl = containerUrl.appendingPathComponent("media")
+
+      do {
+        try fileManager.removeItem(at: mediaUrl)
+      } catch {
+        print("Error removing media folder: \(error)")
+      }
+    }
   }
 }

--- a/plugin/swift/ShareExtensionViewController.swift
+++ b/plugin/swift/ShareExtensionViewController.swift
@@ -262,9 +262,9 @@ class ShareExtensionViewController: UIViewController {
                   
                   let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
                   
-                  if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
+                  if !fileManager.fileExists(atPath: sharedDataUrl.path) {
                     do {
-                      try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
+                      try fileManager.createDirectory(at: sharedDataUrl, withIntermediateDirectories: true)
                     } catch {
                       print("Failed to create sharedData directory: \(error)")
                     }
@@ -289,9 +289,9 @@ class ShareExtensionViewController: UIViewController {
                   
                   let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
                   
-                  if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
+                  if !fileManager.fileExists(atPath: sharedDataUrl.path) {
                     do {
-                      try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
+                      try fileManager.createDirectory(at: sharedDataUrl, withIntermediateDirectories: true)
                     } catch {
                       print("Failed to create sharedData directory: \(error)")
                     }
@@ -344,9 +344,9 @@ class ShareExtensionViewController: UIViewController {
                   
                   let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
                   
-                  if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
+                  if !fileManager.fileExists(atPath: sharedDataUrl.path) {
                     do {
-                      try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
+                      try fileManager.createDirectory(at: sharedDataUrl, withIntermediateDirectories: true)
                     } catch {
                       print("Failed to create sharedData directory: \(error)")
                     }
@@ -357,7 +357,7 @@ class ShareExtensionViewController: UIViewController {
                   do {
                     try fileManager.copyItem(atPath: tempFilePath, toPath: persistentURL.path)
                     if var videoArray = sharedItems["videos"] as? [String] {
-                      videoArray.append(persistentURL.absoluteString)
+                      videoArray.append(persistentURL.path)
                       sharedItems["videos"] = videoArray
                     }
                   } catch {
@@ -369,12 +369,23 @@ class ShareExtensionViewController: UIViewController {
               else if let videoData = videoItem as? NSData {
                 let fileExtension = "mov" // Using mov as default type extension
                 let fileName = UUID().uuidString + "." + fileExtension
-                let persistentURL = containerUrl.appendingPathComponent(fileName)
-                
+
+                let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
+
+                if !fileManager.fileExists(atPath: sharedDataUrl.path) {
+                  do {
+                    try fileManager.createDirectory(at: sharedDataUrl, withIntermediateDirectories: true)
+                  } catch {
+                    print("Failed to create sharedData directory: \(error)")
+                  }
+                }
+
+                let persistentURL = sharedDataUrl.appendingPathComponent(fileName)
+
                 do {
                   try videoData.write(to: persistentURL)
                   if var videoArray = sharedItems["videos"] as? [String] {
-                    videoArray.append(persistentURL.absoluteString)
+                    videoArray.append(persistentURL.path)
                     sharedItems["videos"] = videoArray
                   }
                 } catch {
@@ -390,9 +401,9 @@ class ShareExtensionViewController: UIViewController {
                 
                 let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
                 
-                if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
+                if !fileManager.fileExists(atPath: sharedDataUrl.path) {
                   do {
-                    try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
+                    try fileManager.createDirectory(at: sharedDataUrl, withIntermediateDirectories: true)
                   } catch {
                     print("Failed to create sharedData directory: \(error)")
                   }

--- a/plugin/swift/ShareExtensionViewController.swift
+++ b/plugin/swift/ShareExtensionViewController.swift
@@ -259,7 +259,18 @@ class ShareExtensionViewController: UIViewController {
                 if let tempFilePath = imageUri.path {
                   let fileExtension = imageUri.pathExtension ?? "jpg"
                   let fileName = UUID().uuidString + "." + fileExtension
-                  let persistentURL = containerUrl.appendingPathComponent(fileName)
+                  
+                  let mediaDirectory = containerUrl.appendingPathComponent("media")
+                  
+                  if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                    do {
+                      try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                    } catch {
+                      print("Failed to create media directory: \(error)")
+                    }
+                  }
+                  
+                  let persistentURL = mediaDirectory.appendingPathComponent(fileName)
                   
                   do {
                     try fileManager.copyItem(atPath: tempFilePath, toPath: persistentURL.path)
@@ -275,7 +286,18 @@ class ShareExtensionViewController: UIViewController {
                 // Handle UIImage if needed (e.g., save to disk and get the file path)
                 if let imageData = image.jpegData(compressionQuality: 1.0) {
                   let fileName = UUID().uuidString + ".jpg"
-                  let persistentURL = containerUrl.appendingPathComponent(fileName)
+
+                  let mediaDirectory = containerUrl.appendingPathComponent("media")
+                  
+                  if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                    do {
+                      try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                    } catch {
+                      print("Failed to create media directory: \(error)")
+                    }
+                  }
+                  
+                  let persistentURL = mediaDirectory.appendingPathComponent(fileName)
                   
                   do {
                     try imageData.write(to: persistentURL)
@@ -319,7 +341,18 @@ class ShareExtensionViewController: UIViewController {
                 if let tempFilePath = videoUri.path {
                   let fileExtension = videoUri.pathExtension ?? "mov"
                   let fileName = UUID().uuidString + "." + fileExtension
-                  let persistentURL = containerUrl.appendingPathComponent(fileName)
+
+                  let mediaDirectory = containerUrl.appendingPathComponent("media")
+                  
+                  if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                    do {
+                      try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                    } catch {
+                      print("Failed to create media directory: \(error)")
+                    }
+                  }
+                  
+                  let persistentURL = mediaDirectory.appendingPathComponent(fileName)
                   
                   do {
                     try fileManager.copyItem(atPath: tempFilePath, toPath: persistentURL.path)
@@ -354,7 +387,18 @@ class ShareExtensionViewController: UIViewController {
                 
                 let fileExtension = "mov" // Using mov as default type extension
                 let fileName = UUID().uuidString + "." + fileExtension
-                let persistentURL = containerUrl.appendingPathComponent(fileName)
+
+                let mediaDirectory = containerUrl.appendingPathComponent("media")
+                
+                if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                  do {
+                    try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                  } catch {
+                    print("Failed to create media directory: \(error)")
+                  }
+                }
+                
+                let persistentURL = mediaDirectory.appendingPathComponent(fileName)
                 
                 exportSession?.outputURL = persistentURL
                 exportSession?.outputFileType = .mov

--- a/plugin/swift/ShareExtensionViewController.swift
+++ b/plugin/swift/ShareExtensionViewController.swift
@@ -260,17 +260,17 @@ class ShareExtensionViewController: UIViewController {
                   let fileExtension = imageUri.pathExtension ?? "jpg"
                   let fileName = UUID().uuidString + "." + fileExtension
                   
-                  let mediaDirectory = containerUrl.appendingPathComponent("media")
+                  let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
                   
-                  if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                  if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
                     do {
-                      try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                      try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
                     } catch {
-                      print("Failed to create media directory: \(error)")
+                      print("Failed to create sharedData directory: \(error)")
                     }
                   }
                   
-                  let persistentURL = mediaDirectory.appendingPathComponent(fileName)
+                  let persistentURL = sharedDataUrl.appendingPathComponent(fileName)
                   
                   do {
                     try fileManager.copyItem(atPath: tempFilePath, toPath: persistentURL.path)
@@ -286,18 +286,18 @@ class ShareExtensionViewController: UIViewController {
                 // Handle UIImage if needed (e.g., save to disk and get the file path)
                 if let imageData = image.jpegData(compressionQuality: 1.0) {
                   let fileName = UUID().uuidString + ".jpg"
-
-                  let mediaDirectory = containerUrl.appendingPathComponent("media")
                   
-                  if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                  let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
+                  
+                  if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
                     do {
-                      try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                      try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
                     } catch {
-                      print("Failed to create media directory: \(error)")
+                      print("Failed to create sharedData directory: \(error)")
                     }
                   }
                   
-                  let persistentURL = mediaDirectory.appendingPathComponent(fileName)
+                  let persistentURL = sharedDataUrl.appendingPathComponent(fileName)
                   
                   do {
                     try imageData.write(to: persistentURL)
@@ -341,18 +341,18 @@ class ShareExtensionViewController: UIViewController {
                 if let tempFilePath = videoUri.path {
                   let fileExtension = videoUri.pathExtension ?? "mov"
                   let fileName = UUID().uuidString + "." + fileExtension
-
-                  let mediaDirectory = containerUrl.appendingPathComponent("media")
                   
-                  if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                  let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
+                  
+                  if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
                     do {
-                      try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                      try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
                     } catch {
-                      print("Failed to create media directory: \(error)")
+                      print("Failed to create sharedData directory: \(error)")
                     }
                   }
                   
-                  let persistentURL = mediaDirectory.appendingPathComponent(fileName)
+                  let persistentURL = sharedDataUrl.appendingPathComponent(fileName)
                   
                   do {
                     try fileManager.copyItem(atPath: tempFilePath, toPath: persistentURL.path)
@@ -387,18 +387,18 @@ class ShareExtensionViewController: UIViewController {
                 
                 let fileExtension = "mov" // Using mov as default type extension
                 let fileName = UUID().uuidString + "." + fileExtension
-
-                let mediaDirectory = containerUrl.appendingPathComponent("media")
                 
-                if !fileManager.fileExists(atPath: mediaDirectory.absoluteString) {
+                let sharedDataUrl = containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData")
+                
+                if !fileManager.fileExists(atPath: sharedDataUrl.absoluteString) {
                   do {
-                    try fileManager.createDirectory(at: containerUrl.appendingPathComponent("media"), withIntermediateDirectories: true)
+                    try fileManager.createDirectory(at: containerUrl.deletingLastPathComponent().appendingPathComponent("sharedData"), withIntermediateDirectories: true)
                   } catch {
-                    print("Failed to create media directory: \(error)")
+                    print("Failed to create sharedData directory: \(error)")
                   }
                 }
                 
-                let persistentURL = mediaDirectory.appendingPathComponent(fileName)
+                let persistentURL = sharedDataUrl.appendingPathComponent(fileName)
                 
                 exportSession?.outputURL = persistentURL
                 exportSession?.outputFileType = .mov

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ export function openHostApp(path: string): void {
   return ExpoShareExtensionModule.openHostApp(path);
 }
 
-export function clearMedia(): void {
-  return ExpoShareExtensionModule.clearMedia();
+export async function clearAppGroupContainer(): Promise<void> {
+  return await ExpoShareExtensionModule.clearAppGroupContainer();
 }
 
 export interface IExtensionPreprocessingJS {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,10 @@ export function openHostApp(path: string): void {
   return ExpoShareExtensionModule.openHostApp(path);
 }
 
+export function clearMedia(): void {
+  return ExpoShareExtensionModule.clearMedia();
+}
+
 export interface IExtensionPreprocessingJS {
   run: (args: { completionFunction: (data: unknown) => void }) => void;
   finalize: (args: unknown) => void;


### PR DESCRIPTION
## Motivation

When sharing images and videos via the share extension, `expo-share-extension` creates a `sharedData` directory in the app group's container and stores the image/video files in it. These files are not removed automatically, because `expo-share-extension` can't know when you're done processing them. You also should not _not_ remove them, because that would unnecessarily use up your users' storage capacity.

## Implementation

This PR introduces an async `clearAppGroupContainer` method, which you can import from `expo-share-extension` to empty the `sharedData` directory at your own terms (e.g. after you're done processing the shared files).

See `examples/with-media/app/create.tsx` for an example implementation