### PR TITLE
fix: use existing app group properly

### DIFF
--- a/plugin/src/withShareExtensionEntitlements.ts
+++ b/plugin/src/withShareExtensionEntitlements.ts
@@ -25,9 +25,7 @@ export const withShareExtensionEntitlements: ConfigPlugin = (config) => {
       config.ios?.entitlements?.["com.apple.security.application-groups"];
 
     let shareExtensionEntitlements: Record<string, string | string[]> = {
-      "com.apple.security.application-groups": [
-        existingAppGroup ?? getAppGroup(bundleIdentifier),
-      ],
+      "com.apple.security.application-groups": existingAppGroup ?? [getAppGroup(bundleIdentifier)],
     };
 
     if (config.ios?.usesAppleSignIn) {


### PR DESCRIPTION
Hi!

When app's original config has `ios.entitlement["com.apple.security.application-groups"]`,
generated shareExtension's entitlement file has wrong type value like this:
```
    <key>com.apple.security.application-groups</key>
    <array>
      <array>
        <string>group.com.xxxxx.xxxxxx</string>
      </array>
    <array>
```

It should be:
```
    <key>com.apple.security.application-groups</key>
    <array>
       <string>group.com.xxxxx.xxxxxx</string>
    <array>
```


I noticed it comes from expo config plugin.
So I added a little change to it.
