### PR TITLE
Support dark mode following system appearance

### DIFF
--- a/plugin/src/withShareExtensionInfoPlist.ts
+++ b/plugin/src/withShareExtensionInfoPlist.ts
@@ -71,7 +71,7 @@ export const withShareExtensionInfoPlist: ConfigPlugin<{
         "UIInterfaceOrientationPortrait",
         "UIInterfaceOrientationPortraitUpsideDown",
       ],
-      UIUserInterfaceStyle: "Light",
+      UIUserInterfaceStyle: "Automatic",
       UIViewControllerBasedStatusBarAppearance: false,
       UIApplicationSceneManifest: {
         UIApplicationSupportsMultipleScenes: true,


### PR DESCRIPTION
resolves #43 

After changing `UIUserInterfaceStyle` to `Automatic` of `Info.plist` for shared extension, tested with below codes. It returns `light` or `dark` following system appearance setting.
```
import { Appearance } from 'react-native';

const colorScheme = Appearance.getColorScheme();
console.log('colorScheme', colorScheme);
```