### PR TITLE
style: Use systemBackground as default background color for better dark mode support

### DIFF
--- a/plugin/swift/ShareExtensionViewController.swift
+++ b/plugin/swift/ShareExtensionViewController.swift
@@ -256,7 +256,7 @@ class ShareExtensionViewController: UIViewController {
   }
   
   private func backgroundColor(from dict: [String: CGFloat]?) -> UIColor {
-    guard let dict = dict else { return .white }
+    guard let dict = dict else { return .systemBackground }
     let red = dict["red"] ?? 255.0
     let green = dict["green"] ?? 255.0
     let blue = dict["blue"] ?? 255.0


### PR DESCRIPTION
Hi! First of all, thank you so much for creating and maintaining this amazing expo-share-extension plugin. 
It's been incredibly helpful for my projects! 🙏

## Summary

This PR changes the default background color from `.white` to `.systemBackground` when no custom background color is specified in Info.plist.

## Motivation

When building apps that support both light and dark modes, the share extension should naturally adapt to the system's appearance settings. Currently, when no `ShareExtensionBackgroundColor` is specified in Info.plist, the extension defaults to white, which doesn't look great in dark mode.

## Changes

- Modified `backgroundColor(from:)` function in `ShareExtensionViewController.swift`
- Changed the default return value from `.white` to `.systemBackground`

```swift
// Before
guard let dict = dict else { return .white }

// After
guard let dict = dict else { return .systemBackground }
```

## Impact

- Backward compatibility: Yes - existing apps with custom colors defined in Info.plist will work exactly as before
- New behavior: Apps without a custom background color will now automatically adapt to the system's light/dark mode

## Testing

I've tested this change in my app with:
- Light mode
- Dark mode

Thanks again for your great work on this plugin.