### PR TITLE
fix: add AppGroupIdentifier to plist for compatibility with mmkv

### DIFF
--- a/plugin/src/withAppInfoPlist.ts
+++ b/plugin/src/withAppInfoPlist.ts
@@ -7,6 +7,7 @@ export const withAppInfoPlist: ConfigPlugin = (config) => {
     const bundleIdentifier = getAppBundleIdentifier(config);
 
     config.modResults["AppGroup"] = getAppGroup(bundleIdentifier);
+    config.modResults["AppGroupIdentifier"] = bundleIdentifier;
 
     return config;
   });

--- a/plugin/src/withShareExtensionInfoPlist.ts
+++ b/plugin/src/withShareExtensionInfoPlist.ts
@@ -78,8 +78,9 @@ export const withShareExtensionInfoPlist: ConfigPlugin<{
         UISceneConfigurations: {},
       },
       UIAppFonts: fonts.map((font) => path.basename(font)) ?? [],
-      // we need to add an AppGroup key for compatibility with react-native-mmkv https://github.com/mrousavy/react-native-mmkv
+      // we need to add AppGroup and AppGroupIdentifier keys for compatibility with react-native-mmkv https://github.com/mrousavy/react-native-mmkv
       AppGroup: appGroup,
+      AppGroupIdentifier: bundleIdentifier,
       NSExtension: {
         NSExtensionAttributes: {
           NSExtensionActivationRule: activationRules.reduce((acc, current) => {


### PR DESCRIPTION
### Overview
In v4 of react-native-mmkv the `AppGroup` plist key has been renamed to `AppGroupIdentifier`: https://github.com/mrousavy/react-native-mmkv/pull/877

This PR keeps the `AppGroup` key for backwards compatibility and adds `AppGroupIdentifier` to add support for react-native-mmkv v4+.

I tested this by patching the package in my application and verified that I'm able to use react-native-mmkv v4.0.0 to share storage between the share extension and my host application.