### PR TITLE
fix: prevent Expo SDK 55 share extension fallback startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Exclude unneeded expo modules to reduce the share extension's bundle size by add
 ],
 ```
 
-**Note**: The share extension does not support `expo-updates` as it causes the share extension to crash. Since version `1.5.0`, `expo-updates` is excluded from the share extension's bundle by default. If you're using an older version, you must exclude it by adding it to the `excludedPackages` option in your `app.json`/`app.config.(j|t)s`. See the [Exlude Expo Modules](#exlude-expo-modules) section for more information.
+**Note**: The share extension should not include app-level runtime/dev modules such as `expo-updates`, `expo-dev-client`, `expo-dev-launcher`, and `expo-dev-menu` in its target. These are excluded by default. If you're using an older version, you should exclude them manually via `excludedPackages` in your `app.json`/`app.config.(j|t)s`.
 
 ### React Native Firebase
 

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -36,11 +36,17 @@ export const withPodfile: ConfigPlugin<{
         comment: "#",
       }).contents;
 
-      // we always want to exclude expo-updates because it throws this error when the share extension is triggered
-      // EXUpdates/AppController.swift:151: Assertion failed: AppController.sharedInstace was called before the module was initialized
+      // The share extension runs in its own host context and should not include
+      // app-level dev/runtime modules that expect app windows or update controllers.
+      const defaultExcludedPackages = [
+        "expo-updates",
+        "expo-dev-client",
+        "expo-dev-launcher",
+        "expo-dev-menu",
+      ];
       const exclude = excludedPackages?.length
-        ? Array.from(new Set(["expo-updates", ...excludedPackages]))
-        : ["expo-updates"];
+        ? Array.from(new Set([...defaultExcludedPackages, ...excludedPackages]))
+        : defaultExcludedPackages;
 
       const useExpoModules = `exclude = ["${exclude.join(`", "`)}"]
   use_expo_modules!(exclude: exclude)`;

--- a/plugin/swift/ShareExtensionViewController.swift
+++ b/plugin/swift/ShareExtensionViewController.swift
@@ -12,7 +12,16 @@ import FirebaseCore
 import FirebaseAuth
 #endif
 
-class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
+#if canImport(Expo)
+internal import Expo
+typealias ShareExtensionReactNativeDelegateSuperclass = ExpoReactNativeFactoryDelegate
+typealias ShareExtensionReactNativeFactory = ExpoReactNativeFactory
+#else
+typealias ShareExtensionReactNativeDelegateSuperclass = RCTDefaultReactNativeFactoryDelegate
+typealias ShareExtensionReactNativeFactory = RCTReactNativeFactory
+#endif
+
+class ReactNativeDelegate: ShareExtensionReactNativeDelegateSuperclass {
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     self.bundleURL()
   }
@@ -42,8 +51,8 @@ class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
 
 class ShareExtensionViewController: UIViewController {
   private let loadingIndicator = UIActivityIndicatorView(style: .large)
-  var reactNativeFactory: RCTReactNativeFactory?
-  var reactNativeFactoryDelegate: RCTReactNativeFactoryDelegate?
+  var reactNativeFactory: ShareExtensionReactNativeFactory?
+  var reactNativeFactoryDelegate: ShareExtensionReactNativeDelegateSuperclass?
   private var isCleanedUp = false
 
   deinit {
@@ -98,7 +107,7 @@ class ShareExtensionViewController: UIViewController {
       
       reactNativeFactoryDelegate = ReactNativeDelegate()
       reactNativeFactoryDelegate!.dependencyProvider = RCTAppDependencyProvider()
-      reactNativeFactory = RCTReactNativeFactory(delegate: reactNativeFactoryDelegate!)
+      reactNativeFactory = ShareExtensionReactNativeFactory(delegate: reactNativeFactoryDelegate!)
       
       var initialProps = sharedData ?? [:]
       


### PR DESCRIPTION
## Summary
- use `ExpoReactNativeFactory` / `ExpoReactNativeFactoryDelegate` when Expo is available, so share extensions initialize on the Expo factory path instead of the deprecated `ExpoBridgeModule` fallback path seen in SDK 55 logs
- exclude app-level Expo runtime/dev modules by default in the extension target (`expo-updates`, `expo-dev-client`, `expo-dev-launcher`, `expo-dev-menu`) to avoid extension-host startup conflicts
- keep background/transparency changes separate; those remain in https://github.com/MaxAst/expo-share-extension/pull/111

Closes #109.

Prepared by Codex 5.3.

## Test plan
- [x] `npm run build`
- [x] `npm test -- --passWithNoTests`
- [x] Verified in local Expo SDK 55 app that iOS Safari -> Share -> extension no longer immediately dismisses without an `expo-modules-core` patch

Made with [Cursor](https://cursor.com)