### PR TITLE
fix: prevent crash in openHostApp when path is empty

### DIFF
--- a/plugin/swift/ShareExtensionViewController.swift
+++ b/plugin/swift/ShareExtensionViewController.swift
@@ -185,8 +185,8 @@ class ShareExtensionViewController: UIViewController {
     urlComponents.scheme = scheme
     urlComponents.host = ""
     
-    if let path = path {
-      let pathComponents = path.split(separator: "?", maxSplits: 1)
+    if let path = path, !path.isEmpty {
+      let pathComponents = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
       let pathWithoutQuery = String(pathComponents[0])
       let queryString = pathComponents.count > 1 ? String(pathComponents[1]) : nil
       


### PR DESCRIPTION
## Summary

`openHostApp(path:)` crashes with a fatal **"Index out of range"** when called with an empty string.

Swift's `String.split(separator:)` omits empty subsequences by default, so `"".split(separator: "?")` returns `[]` — accessing `pathComponents[0]` on that empty array crashes the share extension.

## Fix

- Add `!path.isEmpty` guard so empty paths fall through to the no-path URL construction
- Pass `omittingEmptySubsequences: false` so edge cases like `"?redirect=true"` still produce at least one element